### PR TITLE
Fix link title in technologies page

### DIFF
--- a/src/pages/technologies.md
+++ b/src/pages/technologies.md
@@ -7,6 +7,6 @@ eleventyNavigation:
 
 Essa seção apresentará algumas das principais tecnologias e ferramentas que devem ser conhecidas para o desenvolvimento de interfaces acessíveis. Essas tecnologias serão apresentadas em três categorias distintas:
 
-- [Ferramentas de Apoio]({{ 'support' | url }}): Ferramentas que auxiliam desenvolvedores com questões de acessibilidade.
+- [Tecnologias de Apoio]({{ 'support' | url }}): Ferramentas que auxiliam desenvolvedores com questões de acessibilidade.
 - [Tecnologias assistivas]({{ 'assistives' | url }}): As principais tecnologias utilizadas por usuários com necessidades especiais, e o que deve ser levado em conta ao desenvolver interfaces que sejam acessíveis a essas tecnologias.
 - [WAI-ARIA]({{ 'aria' | url }}): Uma introdução breve aos recursos do ARIA, e os cuidados que devem ser tomados ao utilizá-los.


### PR DESCRIPTION
There is a link in the Technologies page called "Ferramentas de Apoio".
But the page title and the left menu bar title refering to this link is titled "Tecnologias de Apoio"

This PR fixes the title!